### PR TITLE
Fix dynamic manifest with variants

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,9 +1,8 @@
-# Dash.js Authors File
-#####Entries should be added as
-* GitHub Name (Required)
-* <Name and/or Organization> (Optional)
+# Dash.js Authors List
+#####Please add entries to the bottom of the list in the following format
+* @GitHub UserName (Required) <Name and/or Organization> (Optional)
 
-#####Authors - (please add your information to the bottom of the list)
+#Authors 
 * @nweber <Digital Primates>
 * @jefftapper <Jeff Tapper - Digital Primates>
 * @KozhinM <Mikail Kozhin - Microsoft Open Technologies>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,45 @@
+# Dash.js Authors File
+#####Entries should be added as
+* GitHub Name (Required)
+* <Name and/or Organization> (Optional)
+
+#####Authors - (please add your information to the bottom of the list)
+* @nweber <Digital Primates>
+* @jefftapper <Jeff Tapper - Digital Primates>
+* @KozhinM <Mikail Kozhin - Microsoft Open Technologies>
+* @kirkshoop <Kirk Shoop - Microsoft Open Technologies>
+* @wilaw <Will Law - Akamai Technologies>
+* @AkamaiDASH <Dan Sparacio - Akamai Technologies>
+* @dsilhavy <Daniel Silhavy - Fraunhofer Fokus>
+* @greg80303 <Greg Rutz - CableLabs>
+* @heff <Steve Hefferman - Brightcove>
+* @Tomjohnson916 <Tom Johnson - Brightcove>
+* @jeroenwiljering <Jeroen Wijering - JWPlayer>
+* @bbcrddave <David Evans - BBC R&D>
+* @bbert <Bertrand Berthelot - Orange>
+* @vigneshvg <Vignesh Venkatasubramanian - Google>
+* @nicosang <Nicolas Angot - Orange>
+* @PriyadarshiniV
+* @senthil-codr <Senthil>
+* @dweremeichik <Dylan Weremeichik>
+* @aleal-envivio 
+* @mconlin
+* @umavinoth
+* @lbonn
+* @mdale <Michael Dale - Kaltura>
+* @sgrebnov <Sergey Grebnov - Microsoft Open Technologies>
+* @wesleytodd <Wes Todd - Vubeology>
+* @colde <Loke Dupont - Xstream>
+* @rgardler <Ross Gardler - Microsoft Open Technologies>
+* @squapp
+* @xiaomings
+* @rcollins112 <Rich Collins - Wowza>
+* @timothy003 <Timothy Liang>
+* @JaapHaitsma
+* @72lions <Thodoris Tsiridis - 72lions>
+* @TobbeMobiTV <Torbjörn Einarsson - MobiTV>
+* @mstorsjo <Martin Storsjö>
+* @Hyddan <Daniel Hedenius>
+* @qjia7
+* @waqarz
+* @WMSPanel <WMSPanel Team>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,44 +1,44 @@
 # Dash.js Authors List
 #####Please add entries to the bottom of the list in the following format
-* @GitHub UserName (Required) <Name and/or Organization> (Optional)
+* @GitHub UserName (Required) [Name and/or Organization] (Optional)
 
 #Authors 
-* @nweber <Digital Primates>
-* @jefftapper <Jeff Tapper - Digital Primates>
-* @KozhinM <Mikail Kozhin - Microsoft Open Technologies>
-* @kirkshoop <Kirk Shoop - Microsoft Open Technologies>
-* @wilaw <Will Law - Akamai Technologies>
-* @AkamaiDASH <Dan Sparacio - Akamai Technologies>
-* @dsilhavy <Daniel Silhavy - Fraunhofer Fokus>
-* @greg80303 <Greg Rutz - CableLabs>
-* @heff <Steve Hefferman - Brightcove>
-* @Tomjohnson916 <Tom Johnson - Brightcove>
-* @jeroenwiljering <Jeroen Wijering - JWPlayer>
-* @bbcrddave <David Evans - BBC R&D>
-* @bbert <Bertrand Berthelot - Orange>
-* @vigneshvg <Vignesh Venkatasubramanian - Google>
-* @nicosang <Nicolas Angot - Orange>
+* @nweber [Digital Primates]
+* @jefftapper [Jeff Tapper, Digital Primates]
+* @KozhinM [Mikail Kozhin, Microsoft Open Technologies]
+* @kirkshoop [Kirk Shoop, Microsoft Open Technologies]
+* @wilaw [Will Law, Akamai Technologies]
+* @AkamaiDASH [Dan Sparacio, Akamai Technologies]
+* @dsilhavy [Daniel Silhavy, Fraunhofer Fokus]
+* @greg80303 [Greg Rutz, CableLabs]
+* @heff [Steve Hefferman, Brightcove]
+* @Tomjohnson916 [Tom Johnson, Brightcove]
+* @jeroenwiljering [Jeroen Wijering, JWPlayer]
+* @bbcrddave [David Evans, BBC R&D]
+* @bbert [Bertrand Berthelot, Orange]
+* @vigneshvg [Vignesh Venkatasubramanian, Google]
+* @nicosang [Nicolas Angot, Orange]
 * @PriyadarshiniV
-* @senthil-codr <Senthil>
-* @dweremeichik <Dylan Weremeichik>
+* @senthil-codr [Senthil]
+* @dweremeichik [Dylan Weremeichik]
 * @aleal-envivio 
 * @mconlin
 * @umavinoth
 * @lbonn
-* @mdale <Michael Dale - Kaltura>
-* @sgrebnov <Sergey Grebnov - Microsoft Open Technologies>
-* @wesleytodd <Wes Todd - Vubeology>
-* @colde <Loke Dupont - Xstream>
-* @rgardler <Ross Gardler - Microsoft Open Technologies>
+* @mdale [Michael Dale, Kaltura]
+* @sgrebnov [Sergey Grebnov, Microsoft Open Technologies]
+* @wesleytodd [Wes Todd, Vubeology]
+* @colde [Loke Dupont, Xstream]
+* @rgardler [Ross Gardler, Microsoft Open Technologies]
 * @squapp
 * @xiaomings
-* @rcollins112 <Rich Collins - Wowza>
-* @timothy003 <Timothy Liang>
+* @rcollins112 [Rich Collins, Wowza]
+* @timothy003 [Timothy Liang]
 * @JaapHaitsma
-* @72lions <Thodoris Tsiridis - 72lions>
-* @TobbeMobiTV <Torbjörn Einarsson - MobiTV>
-* @mstorsjo <Martin Storsjö>
-* @Hyddan <Daniel Hedenius>
+* @72lions [Thodoris Tsiridis, 72lions]
+* @TobbeMobiTV [Torbjörn Einarsson, MobiTV]
+* @mstorsjo [Martin Storsjö]
+* @Hyddan [Daniel Hedenius]
 * @qjia7
 * @waqarz
-* @WMSPanel <WMSPanel Team>
+* @WMSPanel [WMSPanel Team]

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -601,7 +601,11 @@ Dash.dependencies.DashHandler = function () {
             lastIdx = segments.length - 1;
             if (isDynamic && isNaN(this.timelineConverter.getExpectedLiveEdge())) {
                 lastSegment = segments[lastIdx];
-                liveEdge = lastSegment.presentationStartTime + lastSegment.duration;
+                // live edge time is calculated as floor((NOW - (mpd@availabilityStartTime) - (d * 1.5))
+                // where d - segment duration,
+                // 1.5 is used because segment duration can vary by +-50%
+                // NOW - mpd@availabilityStartTime = lastSegment.presentationStartTime + d
+                liveEdge = lastSegment.presentationStartTime - (lastSegment.duration / 2);
                 metrics = this.metricsModel.getMetricsFor("stream");
                 // the last segment is supposed to be a live edge
                 this.timelineConverter.setExpectedLiveEdge(liveEdge);

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -42,7 +42,7 @@ Dash.dependencies.RepresentationController = function () {
                 bitrate = null,
                 streamInfo = self.streamProcessor.getStreamInfo(),
                 quality,
-                maxQuality = self.abrController.getTopQualityIndexFor(type, streamInfo.id),
+                maxQuality = self.abrController.getTopQualityIndexFor(type, streamInfo.id);
 
             updating = true;
             self.notify(Dash.dependencies.RepresentationController.eventList.ENAME_DATA_UPDATE_STARTED);

--- a/src/dash/controllers/RepresentationController.js
+++ b/src/dash/controllers/RepresentationController.js
@@ -66,7 +66,6 @@ Dash.dependencies.RepresentationController = function () {
             if (type !== "video" && type !== "audio" && type !== "fragmentedText") {
                 updating = false;
                 self.notify(Dash.dependencies.RepresentationController.eventList.ENAME_DATA_UPDATE_COMPLETED, {data: data, currentRepresentation: currentRepresentation});
-                addRepresentationSwitch.call(self);
                 return;
             }
 
@@ -182,7 +181,6 @@ Dash.dependencies.RepresentationController = function () {
                 self.abrController.setPlaybackQuality(self.streamProcessor.getType(), self.streamProcessor.getStreamInfo(), getQualityForRepresentation.call(this, currentRepresentation));
                 self.metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {latency: currentRepresentation.segmentAvailabilityRange.end - self.streamProcessor.playbackController.getTime()});
                 this.notify(Dash.dependencies.RepresentationController.eventList.ENAME_DATA_UPDATE_COMPLETED, {data: data, currentRepresentation: currentRepresentation});
-                addRepresentationSwitch.call(self);
             }
         },
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -282,6 +282,7 @@ MediaPlayer = function (context) {
          *
          */
         addEventListener: function (type, listener, useCapture) {
+            type = type.toLowerCase();
             this.eventBus.addEventListener(type, listener, useCapture);
         },
 
@@ -292,6 +293,7 @@ MediaPlayer = function (context) {
          * @memberof MediaPlayer#
          */
         removeEventListener: function (type, listener, useCapture) {
+            type = type.toLowerCase();
             this.eventBus.removeEventListener(type, listener, useCapture);
         },
 

--- a/src/streaming/rules/SchedulingRules/PlaybackTimeRule.js
+++ b/src/streaming/rules/SchedulingRules/PlaybackTimeRule.js
@@ -103,7 +103,7 @@ MediaPlayer.rules.PlaybackTimeRule = function () {
             request = this.adapter.getFragmentRequestForTime(streamProcessor, track, time, {keepIdx: keepIdx});
 
             if (useRejected && request && request.index !== rejected.index) {
-                request = this.adapter.getFragmentRequestForTime(streamProcessor, track, rejected.startTime + (rejected.duration / 2) + EPSILON, {keepIdx: keepIdx});
+                request = this.adapter.getFragmentRequestForTime(streamProcessor, track, rejected.startTime + (rejected.duration / 2) + EPSILON, {keepIdx: keepIdx, timeThreshold: 0});
             }
 
             while (request && streamProcessor.getFragmentModel().isFragmentLoadedOrPending(request)) {

--- a/src/streaming/rules/SchedulingRules/PlaybackTimeRule.js
+++ b/src/streaming/rules/SchedulingRules/PlaybackTimeRule.js
@@ -73,6 +73,7 @@ MediaPlayer.rules.PlaybackTimeRule = function () {
                 keepIdx = !!rejected && !hasSeekTarget,
                 currentTime = this.adapter.getIndexHandlerTime(streamProcessor),
                 playbackTime = streamProcessor.playbackController.getTime(),
+                liveStartTime = streamProcessor.playbackController.getLiveStartTime(),
                 rejectedEnd = rejected ? rejected.startTime + rejected.duration : null,
                 useRejected = !hasSeekTarget && rejected && ((rejectedEnd > playbackTime) && (rejected.startTime <= currentTime) || isNaN(currentTime)),
                 range,
@@ -88,6 +89,10 @@ MediaPlayer.rules.PlaybackTimeRule = function () {
             if (isNaN(time)) {
                 callback(new MediaPlayer.rules.SwitchRequest(null, p));
                 return;
+            }
+
+            if (time === 0 && liveStartTime > 0) {
+                time = liveStartTime;
             }
 
             if (seekTarget[streamId]) {

--- a/src/streaming/utils/CustomTimeRanges.js
+++ b/src/streaming/utils/CustomTimeRanges.js
@@ -83,10 +83,11 @@ MediaPlayer.utils.CustomTimeRanges = function () {
                     //            or
                     //|-----------------Range i----------------|
                     //|-------Range to remove -----|
-                    this.customTimeRangeArray[i].end=start;
+                    this.customTimeRangeArray[i].start=end;
                 }
             }
-            
+
+            this.length = this.customTimeRangeArray.length;
         },
         mergeRanges : function(rangeIndex1,rangeIndex2) {
             var range1=this.customTimeRangeArray[rangeIndex1];


### PR DESCRIPTION
With dynamic manifests, that have multiple variants and there is no longer a 0 time listed in the manifest, there was an issue where the player would continually attempt to look up the index of time 0 and so never begin playback starting at the latest time available (minus the minimum buffer time).

E.g. when the segment timeline looks something like this...

<SegmentTimeline>
  <S t="612343" d="4126" />
  <S d="4158" />
  ...
</SegmentTimeline>
